### PR TITLE
Hotfix/node 257 xxe refactor

### DIFF
--- a/models/xxe.js
+++ b/models/xxe.js
@@ -7,6 +7,6 @@ module.exports = function XmlExternalEntityModel() {
   return {
     ...routeMeta,
     sinkData,
-    attackXml: content.xxe.attackXml
+    input: content.xxe.attackXml
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,14 +37,14 @@
             }
         },
         "@contrast/test-bench-content": {
-            "version": "2.1.0-beta.0",
-            "resolved": "https://registry.npmjs.org/@contrast/test-bench-content/-/test-bench-content-2.1.0-beta.0.tgz",
-            "integrity": "sha512-X+hspxfO7FzvQROAcxC2XBZCeolpnuI4TvM1bxk/ppWSlNslLzD9jSXxKs0wEHgsJ+DZR5uFC35VpwfLBI/G7g=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@contrast/test-bench-content/-/test-bench-content-2.1.0.tgz",
+            "integrity": "sha512-ZAsPcZezchILc9Yi4niTT4iNHFLLzl0AvWnDoQ+x1LsCvDdjC9upCJabDWKDYKMx8X4dRE/bpv6T/oiKS+Mzvw=="
         },
         "@contrast/test-bench-utils": {
-            "version": "2.2.0-beta.0",
-            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.2.0-beta.0.tgz",
-            "integrity": "sha512-FZ7jbLsOHZhp/mzGejqIP+PMEZzKAu2C7fbKqe37k+JHJsM1iCw+L7D/8f7ga0AX466ehkUuFOhfqJ2V0pjgzQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.2.1.tgz",
+            "integrity": "sha512-GwEckVnyGiikrRGqezYr6XkYMED6wTUmRILYQWEsPXeOsIhuR+jO3TuJfCZq+kJV/1s/T2WYbwbrG2TQ4IiD1A==",
             "requires": {
                 "axios": "^0.19.0",
                 "bent": "^1.5.13",
@@ -56,7 +56,7 @@
                 "node-fetch": "^2.6.0",
                 "pg": "^7.12.0",
                 "request": "^2.88.0",
-                "sequelize": "^5.12.3",
+                "sequelize": "^5.21.1",
                 "sql-template-strings": "^2.2.2",
                 "superagent": "^5.0.5"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,9 @@
             "integrity": "sha512-ZAsPcZezchILc9Yi4niTT4iNHFLLzl0AvWnDoQ+x1LsCvDdjC9upCJabDWKDYKMx8X4dRE/bpv6T/oiKS+Mzvw=="
         },
         "@contrast/test-bench-utils": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.2.1.tgz",
-            "integrity": "sha512-GwEckVnyGiikrRGqezYr6XkYMED6wTUmRILYQWEsPXeOsIhuR+jO3TuJfCZq+kJV/1s/T2WYbwbrG2TQ4IiD1A==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.2.2.tgz",
+            "integrity": "sha512-Ae4Vie9WMER5nSTfLG8hAhAMQhZcGA86FxsIdgEFkqL00wTKyhEEP2761T+t/fExorcPcBcf9n1lSi3+dejL3g==",
             "requires": {
                 "axios": "^0.19.0",
                 "bent": "^1.5.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,14 +37,14 @@
             }
         },
         "@contrast/test-bench-content": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@contrast/test-bench-content/-/test-bench-content-2.0.0.tgz",
-            "integrity": "sha512-cyLSC3nt+6M8/bmUY8dhDopsx3DOXc82T21Hkogy75V93k9ziKsRKJBKogyxynDHgQSowUnbw1ZsoR1GkYeEoQ=="
+            "version": "2.1.0-beta.0",
+            "resolved": "https://registry.npmjs.org/@contrast/test-bench-content/-/test-bench-content-2.1.0-beta.0.tgz",
+            "integrity": "sha512-X+hspxfO7FzvQROAcxC2XBZCeolpnuI4TvM1bxk/ppWSlNslLzD9jSXxKs0wEHgsJ+DZR5uFC35VpwfLBI/G7g=="
         },
         "@contrast/test-bench-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.1.0.tgz",
-            "integrity": "sha512-seeclPkjLXyx9dVL8zu1YnSlDHXIOovwG3RiSVjuuaAI9UCfRAvuuwkj7G5oA2i5Mr8bmfitX5zlA9ihkvl1Lg==",
+            "version": "2.2.0-beta.0",
+            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.2.0-beta.0.tgz",
+            "integrity": "sha512-FZ7jbLsOHZhp/mzGejqIP+PMEZzKAu2C7fbKqe37k+JHJsM1iCw+L7D/8f7ga0AX466ehkUuFOhfqJ2V0pjgzQ==",
             "requires": {
                 "axios": "^0.19.0",
                 "bent": "^1.5.13",
@@ -7400,9 +7400,9 @@
             }
         },
         "sequelize": {
-            "version": "5.19.8",
-            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.19.8.tgz",
-            "integrity": "sha512-PeI40+HQFQkDleFh1oIfOoalCCq4lePps+sUegNJMEzmy1UT5PsE5ob8Ljon9vOtMouqcWJ6OPS1GwFIaPEuaA==",
+            "version": "5.21.1",
+            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.1.tgz",
+            "integrity": "sha512-JI+53MwcClfCFUPJT/l2dDzSpEzWAueyCZus33L/yhJxKTisfdd9OHrUPQ6/dI5nR5eIYT/EafrjkqTAlEQS2w==",
             "requires": {
                 "bluebird": "^3.5.0",
                 "cls-bluebird": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "node": ">=8.11.3"
   },
   "dependencies": {
-    "@contrast/test-bench-content": "^2.0.0",
-    "@contrast/test-bench-utils": "^2.1.0",
+    "@contrast/test-bench-content": "^2.1.0-beta.0",
+    "@contrast/test-bench-utils": "^2.2.0-beta.0",
     "construx": "^1.0.0",
     "construx-copier": "^1.0.0",
     "construx-dustjs": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@contrast/test-bench-content": "^2.1.0",
-    "@contrast/test-bench-utils": "^2.2.1",
+    "@contrast/test-bench-utils": "^2.2.2",
     "construx": "^1.0.0",
     "construx-copier": "^1.0.0",
     "construx-dustjs": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "node": ">=8.11.3"
   },
   "dependencies": {
-    "@contrast/test-bench-content": "^2.1.0-beta.0",
-    "@contrast/test-bench-utils": "^2.2.0-beta.0",
+    "@contrast/test-bench-content": "^2.1.0",
+    "@contrast/test-bench-utils": "^2.2.1",
     "construx": "^1.0.0",
     "construx-copier": "^1.0.0",
     "construx-dustjs": "^1.1.0",

--- a/utils/controllerFactory.js
+++ b/utils/controllerFactory.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const { get } = require('lodash');
+const {
+  utils: { getInput }
+} = require('@contrast/test-bench-utils');
 
 /**
  * Custom response functions allow you to change the functionality or return
@@ -17,17 +19,6 @@ const { get } = require('lodash');
  * @type {ResponseFn}
  */
 const defaultRespond = (result, req, res, next) => res.send(result);
-
-/**
- * Gets the proper input from either req or from model
- * @param {Object} params
- * @param {Object} params.model Kraken model
- * @param {Object} params.req IncomingMessage
- * @param {string} params.key key on request to get input from
- */
-function getInput({ model, req, key }) {
-  return model.input || get(req, key).input;
-}
 
 /**
  * Configures a route to handle sinks configured by our shared test-bench-utils

--- a/utils/controllerFactory.js
+++ b/utils/controllerFactory.js
@@ -45,20 +45,19 @@ module.exports = function controllerFactory(
 
     model.sinkData.forEach(({ method, uri, sink, key }) => {
       router[method](`${uri}/safe`, async (req, res, next) => {
-        const input = getInput({ model, req, key });
+        const input = getInput({ locals: model, req, key });
         const result = await sink(input, { safe: true });
         respond(result, req, res, next);
       });
 
       router[method](`${uri}/unsafe`, async (req, res, next) => {
-        const input = getInput({ model, req, key });
-        console.log('my input', input);
+        const input = getInput({ locals: model, req, key });
         const result = await sink(input);
         respond(result, req, res, next);
       });
 
       router[method](`${uri}/noop`, async (req, res, next) => {
-        const input = getInput({ model, req, key });
+        const input = 'NOOP';
         const result = await sink(input, { noop: true });
         respond(result, req, res, next);
       });

--- a/utils/controllerFactory.js
+++ b/utils/controllerFactory.js
@@ -26,7 +26,7 @@ const defaultRespond = (result, req, res, next) => res.send(result);
  * @param {string} params.key key on request to get input from
  */
 function getInput({ model, req, key }) {
-  return model.input || get(req, key);
+  return model.input || get(req, key).input;
 }
 
 /**

--- a/utils/controllerFactory.js
+++ b/utils/controllerFactory.js
@@ -19,6 +19,17 @@ const { get } = require('lodash');
 const defaultRespond = (result, req, res, next) => res.send(result);
 
 /**
+ * Gets the proper input from either req or from model
+ * @param {Object} params
+ * @param {Object} params.model Kraken model
+ * @param {Object} params.req IncomingMessage
+ * @param {string} params.key key on request to get input from
+ */
+function getInput({ model, req, key }) {
+  return model.input || get(req, key);
+}
+
+/**
  * Configures a route to handle sinks configured by our shared test-bench-utils
  * module.
  *
@@ -43,19 +54,20 @@ module.exports = function controllerFactory(
 
     model.sinkData.forEach(({ method, uri, sink, key }) => {
       router[method](`${uri}/safe`, async (req, res, next) => {
-        const { input } = get(req, key);
+        const input = getInput({ model, req, key });
         const result = await sink(input, { safe: true });
         respond(result, req, res, next);
       });
 
       router[method](`${uri}/unsafe`, async (req, res, next) => {
-        const { input } = get(req, key);
+        const input = getInput({ model, req, key });
+        console.log('my input', input);
         const result = await sink(input);
         respond(result, req, res, next);
       });
 
       router[method](`${uri}/noop`, async (req, res, next) => {
-        const { input } = get(req, key);
+        const input = getInput({ model, req, key });
         const result = await sink(input, { noop: true });
         respond(result, req, res, next);
       });


### PR DESCRIPTION
Changed how we get inputs, specifically for input-less rules(XXE).  The big changes were in the shared libs that I just bumped versions

**Utils**: https://github.com/Contrast-Security-OSS/test-bench-utils/commit/105bd65c84a7348a34c189b03a1a989ec3c85d0b
**Content**: https://github.com/Contrast-Security-OSS/test-bench-content/commit/f85956409572fa15d68abbedc06e0c82a458f738

The 2 big issues were: we were posting the xml with the request which was also causing reflected-xss to fire. I changed the request to a get because there's no input data for this rule

I ran screener with an updated config, PR coming in that repo