### PR TITLE
moved cookie route to cmdi

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -20,7 +20,7 @@
             "csrf": {
               "blacklist": [
                 "/xss/body",
-                "/xss/cookies",
+                "/cmdInjection/cookies",
                 "/unsafeFileUpload/body"
               ]
             },

--- a/models/cmdInjection.js
+++ b/models/cmdInjection.js
@@ -3,9 +3,11 @@ const { utils } = require('@contrast/test-bench-utils');
 module.exports = function CommandInjectionModel() {
   const sinkData = utils.getSinkData('cmdInjection', 'kraken');
   const routeMeta = utils.getRouteMeta('cmdInjection');
+  const groupedSinkData = utils.groupSinkData(sinkData);
 
   return {
     ...routeMeta,
-    sinkData
+    sinkData,
+    groupedSinkData
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,14 +37,14 @@
             }
         },
         "@contrast/test-bench-content": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@contrast/test-bench-content/-/test-bench-content-2.1.0.tgz",
-            "integrity": "sha512-ZAsPcZezchILc9Yi4niTT4iNHFLLzl0AvWnDoQ+x1LsCvDdjC9upCJabDWKDYKMx8X4dRE/bpv6T/oiKS+Mzvw=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@contrast/test-bench-content/-/test-bench-content-2.2.0.tgz",
+            "integrity": "sha512-wYNcKuLlpbJhxD4NUR50EedhO/WptwkfEkTxhzrBLcQK6Gv1MyV3ZaBbw/mgwC9h3+/ThxiTtri9Xd8lNs+k2A=="
         },
         "@contrast/test-bench-utils": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.2.2.tgz",
-            "integrity": "sha512-Ae4Vie9WMER5nSTfLG8hAhAMQhZcGA86FxsIdgEFkqL00wTKyhEEP2761T+t/fExorcPcBcf9n1lSi3+dejL3g==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-2.3.0.tgz",
+            "integrity": "sha512-YITlzjuG2oJEuOAJIJUF5+1QoYXxrL3fjkkvSnSADBbMkZf/GDIycMndxVZ+yGmnhH9UVK2SuuqsAcnqZobwCQ==",
             "requires": {
                 "axios": "^0.19.0",
                 "bent": "^1.5.13",
@@ -592,9 +592,9 @@
             }
         },
         "bson": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
-            "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+            "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -7400,9 +7400,9 @@
             }
         },
         "sequelize": {
-            "version": "5.21.1",
-            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.1.tgz",
-            "integrity": "sha512-JI+53MwcClfCFUPJT/l2dDzSpEzWAueyCZus33L/yhJxKTisfdd9OHrUPQ6/dI5nR5eIYT/EafrjkqTAlEQS2w==",
+            "version": "5.21.2",
+            "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.2.tgz",
+            "integrity": "sha512-MEqJ9NwQi4oy/ylLb2WkfPmhki/BOXC/gJfc8uWUUTETcpLwD1y/5bI1kqVh+qWcECHNsE9G4lmhj5hFbsxqvA==",
             "requires": {
                 "bluebird": "^3.5.0",
                 "cls-bluebird": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "node": ">=8.11.3"
   },
   "dependencies": {
-    "@contrast/test-bench-content": "^2.1.0",
-    "@contrast/test-bench-utils": "^2.2.2",
+    "@contrast/test-bench-content": "^2.2.0",
+    "@contrast/test-bench-utils": "^2.3.0",
     "construx": "^1.0.0",
     "construx-copier": "^1.0.0",
     "construx-dustjs": "^1.1.0",


### PR DESCRIPTION
When we were abstracting out sinks and views the cookie source routes were applied to reflected xss. This is only applicable to assess. I moved them to cmd injection. To verify this works:

 * Run agent with this PR
 * curl http://localhost:3000/cmdInjection/cookies/childProcessExec/unsafe -X POST -b "input=test &whoami"
It should report cmd injection in protect. It should report finding in assess